### PR TITLE
Port 8081 has been assigned to this service, and example properties have been added for local development.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <m2e.apt.activation>jdt_apt</m2e.apt.activation>
         <org.mapstruct.version>1.2.0.Final</org.mapstruct.version>
         <org.projectlombok.version>1.16.18</org.projectlombok.version>
-        <environment>dev</environment>
+        <environment>${ENV_VAR}</environment>
         <target-properties>target/classes/application.properties</target-properties>
         <source-properties>src/main/environment/common_${environment}.properties</source-properties>
         <maven.test.skip>true</maven.test.skip>

--- a/src/main/environment/common_example.properties
+++ b/src/main/environment/common_example.properties
@@ -1,0 +1,22 @@
+server.port=8081
+# FHIR Config
+fhir-url=http://localhost:8093/
+
+ # TM Config
+tm-url=http://localhost:8089/
+##--------------------------------------------## Primary db-------------------------------------------------------------------
+
+spring.datasource.url=jdbc:mysql://localhost:3306/db_iemr
+spring.datasource.username=root
+spring.datasource.password=1234
+spring.datasource.driver-class-name=com.mysql.jdbc.Driver
+
+##--------------------------------------------## Secondary db-------------------------------------------------------------------
+
+secondary.datasource.url=jdbc:mysql://localhost:3306/db_reporting
+secondary.datasource.username=root
+secondary.datasource.password=1234
+secondary.datasource.driver-class-name=com.mysql.jdbc.Driver
+
+springdoc.api-docs.enabled=true
+springdoc.swagger-ui.enabled=true


### PR DESCRIPTION
## 📋 Description

The service is configured to run on port **8081** for local development environments. Additionally, **example** configuration properties have been included to facilitate seamless setup and testing during the development phase. These properties ensure that developers can quickly get the service up and running with minimal configuration, adhering to local environment standards.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Configuration**
  - Added dynamic environment configuration support
  - Configured server port to 8081
  - Added FHIR and TM service URL configurations

- **Dependencies**
  - Integrated Redis support
  - Added OpenAPI documentation capabilities
  - Included additional libraries for data handling and mapping

- **Database**
  - Configured primary and secondary MySQL database connections
  - Enabled API documentation and Swagger UI

<!-- end of auto-generated comment: release notes by coderabbit.ai -->