### PR TITLE
fix: ensure jwt is not in deny list before further authentication

### DIFF
--- a/src/main/java/com/iemr/flw/utils/JwtUtil.java
+++ b/src/main/java/com/iemr/flw/utils/JwtUtil.java
@@ -19,32 +19,39 @@ public class JwtUtil {
 
 	@Value("${jwt.secret}")
 	private String SECRET_KEY;
+	
+	@Autowired
+	private TokenDenylist tokenDenylist;
 
 	private static final long EXPIRATION_TIME = 24L * 60 * 60 * 1000; // 1 day in milliseconds
 
 	// Generate a key using the secret
-	private Key getSigningKey() {
+	private SecretKey getSigningKey() {
 		if (SECRET_KEY == null || SECRET_KEY.isEmpty()) {
 			throw new IllegalStateException("JWT secret key is not set in application.properties");
 		}
 		return Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
 	}
 
-	// Generate JWT Token
-	public String generateToken(String username, String userId) {
-		Date now = new Date();
-		Date expiryDate = new Date(now.getTime() + EXPIRATION_TIME);
 
-		// Include the userId in the JWT claims
-		return Jwts.builder().setSubject(username).claim("userId", userId) // Add userId as a claim
-				.setIssuedAt(now).setExpiration(expiryDate).signWith(getSigningKey(), SignatureAlgorithm.HS256)
-				.compact();
-	}
 
 	// Validate and parse JWT Token
 	public Claims validateToken(String token) {
 		try {
-			return Jwts.parser().setSigningKey(getSigningKey()).build().parseClaimsJws(token).getBody();
+			Claims claims = Jwts.parser()
+				.verifyWith(getSigningKey())
+				.build()
+				.parseSignedClaims(token)
+				.getPayload();
+				
+			String jti = claims.getId();
+			
+			// Check if token is denylisted (only if jti exists)
+			if (jti != null && tokenDenylist.isTokenDenylisted(jti)) {
+				return null;
+			}
+			
+			return claims;
 		} catch (Exception e) {
 			return null; // Handle token parsing/validation errors
 		}
@@ -75,10 +82,13 @@ public class JwtUtil {
 
 	public <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
 		final Claims claims = extractAllClaims(token);
-		return claimsResolver.apply(claims);
+		return claims != null ? claimsResolver.apply(claims) : null;
 	}
 
 	private Claims extractAllClaims(String token) {
-		return Jwts.parser().setSigningKey(getSigningKey()).build().parseClaimsJws(token).getBody();
-	}
+		return Jwts.parser()
+				.verifyWith(getSigningKey())
+				.build()
+				.parseSignedClaims(token)
+				.getPayload();	}
 }

--- a/src/main/java/com/iemr/flw/utils/JwtUtil.java
+++ b/src/main/java/com/iemr/flw/utils/JwtUtil.java
@@ -1,9 +1,9 @@
 package com.iemr.flw.utils;
 
-import java.security.Key;
-import java.util.Date;
 import java.util.function.Function;
+import javax.crypto.SecretKey;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -11,7 +11,6 @@ import com.iemr.flw.utils.exception.IEMRException;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 
 @Component
@@ -23,8 +22,6 @@ public class JwtUtil {
 	@Autowired
 	private TokenDenylist tokenDenylist;
 
-	private static final long EXPIRATION_TIME = 24L * 60 * 60 * 1000; // 1 day in milliseconds
-
 	// Generate a key using the secret
 	private SecretKey getSigningKey() {
 		if (SECRET_KEY == null || SECRET_KEY.isEmpty()) {
@@ -32,8 +29,6 @@ public class JwtUtil {
 		}
 		return Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
 	}
-
-
 
 	// Validate and parse JWT Token
 	public Claims validateToken(String token) {

--- a/src/main/java/com/iemr/flw/utils/TokenDenylist.java
+++ b/src/main/java/com/iemr/flw/utils/TokenDenylist.java
@@ -1,0 +1,55 @@
+package com.iemr.flw.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+public class TokenDenylist {
+    private final Logger logger = LoggerFactory.getLogger(this.getClass().getName());
+    
+    private static final String PREFIX = "denied_";
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    private String getKey(String jti) {
+        return PREFIX + jti;
+    }  
+    
+    // Add a token's jti to the denylist with expiration time
+    public void addTokenToDenylist(String jti, Long expirationTime) {
+        if (jti == null || jti.trim().isEmpty()) {
+            return;
+        }
+        if (expirationTime == null || expirationTime <= 0) {
+            throw new IllegalArgumentException("Expiration time must be positive");
+        }
+
+        try {
+            String key = getKey(jti);  // Use helper method to get the key
+            redisTemplate.opsForValue().set(key, " ", expirationTime, TimeUnit.MILLISECONDS);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to denylist token", e);
+        }
+    }
+
+    // Check if a token's jti is in the denylist
+    public boolean isTokenDenylisted(String jti) {
+        if (jti == null || jti.trim().isEmpty()) {
+            return false;
+        }
+        try {
+            String key = getKey(jti);  // Use helper method to get the key
+            return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+        } catch (Exception e) {
+            logger.error("Failed to check denylist status for jti: " + jti, e);
+            // In case of Redis failure, consider the token as not denylisted to avoid blocking all requests
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## 📋 Description

JIRA ID: AMM-1507

Check if jti is present in deny list before authenticating.
---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [x] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced token denylist support, enhancing security by allowing tokens to be invalidated and checked against a denylist.
- **Bug Fixes**
	- Improved token validation to safely handle null values and prevent errors during claim extraction.
- **Refactor**
	- Updated token parsing and validation to use the latest JWT API, improving reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->