### PR TITLE
fix: save minimal data to users_<id> key of Redis

### DIFF
--- a/src/main/java/com/iemr/flw/utils/JwtAuthenticationUtil.java
+++ b/src/main/java/com/iemr/flw/utils/JwtAuthenticationUtil.java
@@ -112,15 +112,21 @@ public class JwtAuthenticationUtil {
 		M_User user = userLoginRepo.getUserByUserID(Integer.parseInt(userId));
 
 		if (user != null) {
-			// Cache the user in Redis for future requests (cache for 30 minutes)
-			redisTemplate.opsForValue().set(redisKey, user, 30, TimeUnit.MINUTES);
+			M_User userHash = new M_User();
+			userHash.setUserID(user.getUserID());
+			userHash.setUserName(user.getUserName());
+
+			// Cache the minimal user in Redis for future requests (cache for 30 minutes)
+			redisTemplate.opsForValue().set(redisKey, userHash, 30, TimeUnit.MINUTES);
 
 			// Log that the user has been stored in Redis
 			logger.info("User stored in Redis with key: " + redisKey);
+
+			return user;
 		} else {
 			logger.warn("User not found for userId: " + userId);
 		}
 
-		return user;
+		return null;
 	}
 }


### PR DESCRIPTION
This PR implements changes to save minimal data to users_<id> key of Redis

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved user data caching to store only essential user information, enhancing privacy and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->