### PR TITLE
fix: prevent SQL and exception details from leaking in authorization error responses

### DIFF
--- a/src/main/java/com/iemr/flw/utils/JwtAuthenticationUtil.java
+++ b/src/main/java/com/iemr/flw/utils/JwtAuthenticationUtil.java
@@ -87,7 +87,7 @@ public class JwtAuthenticationUtil {
 			return true; // Valid userId and JWT token
 		} catch (Exception e) {
 			logger.error("Validation failed: " + e.getMessage(), e);
-			throw new IEMRException("Validation error: " + e.getMessage(), e);
+			throw new IEMRException("Validation error: Authentication failed", e);
 		}
 	}
 

--- a/src/main/java/com/iemr/flw/utils/JwtUserIdValidationFilter.java
+++ b/src/main/java/com/iemr/flw/utils/JwtUserIdValidationFilter.java
@@ -116,7 +116,7 @@ public class JwtUserIdValidationFilter implements Filter {
 
 		} catch (Exception e) {
 			logger.error("Authorization error: ", e);
-			response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Authorization error: " + e.getMessage());
+			response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Authorization error: Authentication failed");
 		}
 	}
 


### PR DESCRIPTION
## 📋 Description

JIRA ID: [AMM-2155](https://support.piramalfoundation.org/jira/browse/AMM-2155)

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

## Summary
- Fixed SQL query and internal exception details being exposed in HTTP error responses during JWT authentication failure
- Exception messages from DB errors (e.g., `PreparedStatementCallback`, SQL grammar errors) were being concatenated directly into the response body and returned to the client
- Replaced dynamic exception message with a generic static error message; full exception detail is still logged server-side
