### PR TITLE
feat: add facilityData to getUserDetail API response based on user role

### DIFF
--- a/src/main/java/com/iemr/flw/dto/iemr/UserServiceRoleDTO.java
+++ b/src/main/java/com/iemr/flw/dto/iemr/UserServiceRoleDTO.java
@@ -4,6 +4,8 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.Map;
+
 @Data
 @Getter
 @Setter
@@ -23,6 +25,7 @@ public class UserServiceRoleDTO {
     private String blockName;
     private String villageId;
     private String villageName;
+    private Map<String, Object> facilityData;
 
     public UserServiceRoleDTO(Integer userId, String name, String userName, Integer stateId, String stateName, Integer workingDistrictId, String workingDistrictName, Short serviceProviderId, Integer roleId, String roleName, Integer providerServiceMapId, Integer blockId, String blockName, String villageId, String villageName) {
         this.userId = userId;

--- a/src/main/java/com/iemr/flw/repo/iemr/FacilityLoginRepo.java
+++ b/src/main/java/com/iemr/flw/repo/iemr/FacilityLoginRepo.java
@@ -62,4 +62,32 @@ public interface FacilityLoginRepo extends CrudRepository<AshaSupervisorMapping,
 			+ "AND usrm.Deleted = false AND u.Deleted = false", nativeQuery = true)
 	List<Object[]> getPeersAtFacility(@Param("facilityIDs") List<Integer> facilityIDs,
 			@Param("currentUserID") Integer currentUserID);
+
+	// Supervisor: get mapped ASHAs with facility details
+	@Query(value = "SELECT DISTINCT u.UserID, u.FirstName, u.LastName, "
+			+ "COALESCE(u.EmployeeID,'') AS employeeID, "
+			+ "f.FacilityID, f.FacilityName, "
+			+ "COALESCE(ft.FacilityTypeName,'') AS facilityTypeName "
+			+ "FROM asha_supervisor_mapping asm "
+			+ "JOIN m_User u ON u.UserID = asm.ashaUserID "
+			+ "JOIN m_facility f ON f.FacilityID = asm.facilityID "
+			+ "LEFT JOIN m_facilitytype ft ON ft.FacilityTypeID = f.FacilityTypeID "
+			+ "WHERE asm.supervisorUserID = :supervisorUserID "
+			+ "AND asm.deleted = false AND u.Deleted = false AND f.Deleted = false", nativeQuery = true)
+	List<Object[]> getMappedAshasBySupervisor(@Param("supervisorUserID") Integer supervisorUserID);
+
+	// CHO/ANM: get ASHAs at same facilities
+	@Query(value = "SELECT DISTINCT u.UserID, u.FirstName, u.LastName, "
+			+ "COALESCE(u.EmployeeID,'') AS employeeID, "
+			+ "f.FacilityID, f.FacilityName, "
+			+ "COALESCE(ft.FacilityTypeName,'') AS facilityTypeName "
+			+ "FROM m_UserServiceRoleMapping usrm "
+			+ "JOIN m_User u ON u.UserID = usrm.UserID "
+			+ "JOIN m_Role r ON r.RoleID = usrm.RoleID "
+			+ "JOIN m_facility f ON f.FacilityID = usrm.FacilityID "
+			+ "LEFT JOIN m_facilitytype ft ON ft.FacilityTypeID = f.FacilityTypeID "
+			+ "WHERE usrm.FacilityID IN :facilityIDs "
+			+ "AND r.RoleName = 'ASHA' "
+			+ "AND usrm.Deleted = false AND u.Deleted = false AND f.Deleted = false", nativeQuery = true)
+	List<Object[]> getAshaListByFacilities(@Param("facilityIDs") List<Integer> facilityIDs);
 }

--- a/src/main/java/com/iemr/flw/service/impl/FacilityDataService.java
+++ b/src/main/java/com/iemr/flw/service/impl/FacilityDataService.java
@@ -1,0 +1,182 @@
+package com.iemr.flw.service.impl;
+
+import com.iemr.flw.domain.iemr.AshaSupervisorMapping;
+import com.iemr.flw.repo.iemr.AshaSupervisorLoginRepo;
+import com.iemr.flw.repo.iemr.FacilityLoginRepo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+public class FacilityDataService {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass().getName());
+
+    @Autowired
+    private AshaSupervisorLoginRepo ashaSupervisorLoginRepo;
+
+    @Autowired
+    private FacilityLoginRepo facilityLoginRepo;
+
+    public Map<String, Object> buildFacilityData(Integer userID, String roleName) {
+        Map<String, Object> result = new HashMap<>();
+        result.put("location", emptyLocation());
+        try {
+            if ("ASHA Supervisor".equalsIgnoreCase(roleName)) {
+                enrichAshaSupervisorData(result, userID);
+            } else if ("ASHA".equalsIgnoreCase(roleName)) {
+                enrichAshaData(result, userID);
+            } else {
+                enrichGeneralFacilityData(result, userID);
+            }
+        } catch (Exception e) {
+            logger.error("Error building facilityData for userID " + userID + ": " + e.getMessage(), e);
+        }
+        return result;
+    }
+
+    private void enrichAshaSupervisorData(Map<String, Object> result, Integer supervisorUserID) {
+        ArrayList<AshaSupervisorMapping> mappings = ashaSupervisorLoginRepo
+                .findBySupervisorUserIDAndDeletedFalse(supervisorUserID);
+        if (mappings == null || mappings.isEmpty()) return;
+
+        Set<Integer> facilityIDSet = new HashSet<>();
+        for (AshaSupervisorMapping m : mappings) {
+            if (m.getFacilityID() != null) facilityIDSet.add(m.getFacilityID());
+        }
+        if (facilityIDSet.isEmpty()) return;
+        List<Integer> facilityIDs = new ArrayList<>(facilityIDSet);
+
+        List<Object[]> facilityRows = facilityLoginRepo.getFacilityDetails(facilityIDs);
+        if (facilityRows == null || facilityRows.isEmpty()) return;
+
+        result.put("location", buildLocation(facilityRows.get(0)));
+
+        List<Map<String, Object>> facilities = new ArrayList<>();
+        for (Object[] row : facilityRows) {
+            Map<String, Object> facility = new HashMap<>();
+            facility.put("facilityId", row[0]);
+            facility.put("facilityName", str(row[1]));
+            facility.put("facilityType", str(row[9]));
+            facilities.add(facility);
+        }
+        result.put("facilities", facilities);
+
+        List<Object[]> ashaRows = facilityLoginRepo.getMappedAshasBySupervisor(supervisorUserID);
+        List<Map<String, Object>> ashaList = buildAshaList(ashaRows);
+        result.put("ashaList", ashaList);
+        result.put("totalAshaCount", ashaList.size());
+    }
+
+    private void enrichAshaData(Map<String, Object> result, Integer ashaUserID) {
+        List<Integer> facilityIDs = facilityLoginRepo.getUserFacilityIDs(ashaUserID);
+        if (facilityIDs == null || facilityIDs.isEmpty()) return;
+
+        List<Object[]> facilityRows = facilityLoginRepo.getFacilityDetails(facilityIDs);
+        if (facilityRows == null || facilityRows.isEmpty()) return;
+
+        result.put("location", buildLocation(facilityRows.get(0)));
+
+        Object[] row = facilityRows.get(0);
+        Map<String, Object> facility = new HashMap<>();
+        facility.put("facilityId", row[0]);
+        facility.put("facilityName", str(row[1]));
+        facility.put("facilityType", str(row[9]));
+        result.put("facility", facility);
+
+        List<Object[]> supervisorRows = facilityLoginRepo.getSupervisorForAsha(ashaUserID);
+        if (supervisorRows != null && !supervisorRows.isEmpty()) {
+            Object[] sRow = supervisorRows.get(0);
+            Map<String, Object> supervisor = new HashMap<>();
+            supervisor.put("userId", sRow[0]);
+            supervisor.put("fullName", fullName(sRow[1], sRow[2]));
+            supervisor.put("mobile", str(sRow[3]));
+            result.put("supervisor", supervisor);
+        } else {
+            result.put("supervisor", null);
+        }
+
+        List<Object[]> peerRows = facilityLoginRepo.getPeersAtFacility(facilityIDs, ashaUserID);
+        List<Map<String, Object>> peers = new ArrayList<>();
+        if (peerRows != null) {
+            for (Object[] pRow : peerRows) {
+                Map<String, Object> peer = new HashMap<>();
+                peer.put("userId", pRow[0]);
+                peer.put("fullName", fullName(pRow[1], pRow[2]));
+                peer.put("role", str(pRow[3]));
+                peers.add(peer);
+            }
+        }
+        result.put("peersAtFacility", peers);
+    }
+
+    private void enrichGeneralFacilityData(Map<String, Object> result, Integer userID) {
+        List<Integer> facilityIDs = facilityLoginRepo.getUserFacilityIDs(userID);
+        if (facilityIDs == null || facilityIDs.isEmpty()) return;
+
+        List<Object[]> facilityRows = facilityLoginRepo.getFacilityDetails(facilityIDs);
+        if (facilityRows == null || facilityRows.isEmpty()) return;
+
+        result.put("location", buildLocation(facilityRows.get(0)));
+
+        List<Map<String, Object>> facilities = new ArrayList<>();
+        for (Object[] row : facilityRows) {
+            Map<String, Object> facility = new HashMap<>();
+            facility.put("facilityId", row[0]);
+            facility.put("facilityName", str(row[1]));
+            facility.put("facilityType", str(row[9]));
+            facilities.add(facility);
+        }
+        result.put("facilities", facilities);
+
+        List<Object[]> ashaRows = facilityLoginRepo.getAshaListByFacilities(facilityIDs);
+        List<Map<String, Object>> ashaList = buildAshaList(ashaRows);
+        result.put("ashaList", ashaList);
+        result.put("totalAshaCount", ashaList.size());
+    }
+
+    private List<Map<String, Object>> buildAshaList(List<Object[]> rows) {
+        List<Map<String, Object>> list = new ArrayList<>();
+        if (rows == null) return list;
+        for (Object[] row : rows) {
+            Map<String, Object> asha = new HashMap<>();
+            asha.put("userId", row[0]);
+            asha.put("fullName", fullName(row[1], row[2]));
+            asha.put("employeeId", str(row[3]).isEmpty() ? null : str(row[3]));
+            asha.put("facilityId", row[4]);
+            asha.put("facilityName", str(row[5]));
+            asha.put("facilityType", str(row[6]));
+            list.add(asha);
+        }
+        return list;
+    }
+
+    private Map<String, Object> buildLocation(Object[] facilityRow) {
+        Map<String, Object> location = new HashMap<>();
+        location.put("state", str(facilityRow[3]));
+        location.put("district", str(facilityRow[5]));
+        location.put("blockOrUlb", str(facilityRow[7]));
+        location.put("locationType", str(facilityRow[8]));
+        return location;
+    }
+
+    private Map<String, Object> emptyLocation() {
+        Map<String, Object> location = new HashMap<>();
+        location.put("state", "");
+        location.put("district", "");
+        location.put("blockOrUlb", "");
+        location.put("locationType", "");
+        return location;
+    }
+
+    private String str(Object val) {
+        return val != null ? val.toString() : "";
+    }
+
+    private String fullName(Object first, Object last) {
+        return (str(first) + " " + str(last)).trim();
+    }
+}

--- a/src/main/java/com/iemr/flw/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/iemr/flw/service/impl/UserServiceImpl.java
@@ -12,12 +12,17 @@ import org.springframework.stereotype.Service;
 public class UserServiceImpl implements UserService {
 
     private final Logger logger = LoggerFactory.getLogger(UserServiceImpl.class);
+
     @Autowired
     private UserServiceRoleRepo userServiceRoleRepo;
+
+    @Autowired
+    private FacilityDataService facilityDataService;
 
     public UserServiceRoleDTO getUserDetail(Integer userId) {
         logger.info("calling getUserRole for userId: " + userId);
         UserServiceRoleDTO userRole = userServiceRoleRepo.getUserRole(userId).get(0);
+        userRole.setFacilityData(facilityDataService.buildFacilityData(userId, userRole.getRoleName()));
         return userRole;
     }
 }


### PR DESCRIPTION
Add FacilityDataService to build facilityData block (location, facilities, ashaList, totalAshaCount) based on userId and roleName — same logic as login response. ASHA Supervisor gets mapped ashaList, ASHA gets facility
+ supervisor + peers, CHO/ANM get facilities + ashaList at same facility.

## 📋 Description

JIRA ID: [AMM-2301](https://support.piramalfoundation.org/jira/browse/AMM-2301)

Please provide a summary of the change and the motivation behind it. Include relevant context and details.
- Added `facilityData` block to `/flw-api/user/getUserDetail?userId=X` response
- Response is role-based: ASHA Supervisor gets mapped facilities + ashaList + totalAshaCount; ASHA gets own facility + supervisor + peer list; CHO/ANM get facilities + ashaList + totalAshaCount
- No existing response fields changed — only additive

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
