### PR TITLE
fix(nikshay): add Stop TB TU/Facility/District scope to getUserDetail

### DIFF
--- a/src/main/java/com/iemr/flw/dto/iemr/UserServiceRoleDTO.java
+++ b/src/main/java/com/iemr/flw/dto/iemr/UserServiceRoleDTO.java
@@ -27,6 +27,14 @@ public class UserServiceRoleDTO {
     private String villageName;
     private Map<String, Object> facilityData;
 
+    // Stop TB / Nikshay location scope — populated only when serviceName = "Stop TB".
+    // Set via setters after construction (additive, not part of the base constructor
+    // so every other service line's DTO construction stays exactly as it is today).
+    private String tuId;
+    private String tuName;
+    private String healthFacilityId;
+    private String healthFacilityName;
+
     public UserServiceRoleDTO(Integer userId, String name, String userName, Integer stateId, String stateName, Integer workingDistrictId, String workingDistrictName, Short serviceProviderId, Integer roleId, String roleName, Integer providerServiceMapId, Integer blockId, String blockName, String villageId, String villageName) {
         this.userId = userId;
         this.name = name;

--- a/src/main/java/com/iemr/flw/repo/iemr/UserServiceRoleRepo.java
+++ b/src/main/java/com/iemr/flw/repo/iemr/UserServiceRoleRepo.java
@@ -41,4 +41,36 @@ public interface UserServiceRoleRepo extends JpaRepository<UserServiceRole, Inte
             "WHERE db.BlockID = :blockId LIMIT 1", nativeQuery = true)
     List<Object[]> getDistrictByBlockId(@Param("blockId") Integer blockId);
 
+    // Stop TB / Nikshay — additive only. Reads m_userservicerolemapping directly
+    // (NOT the shared v_userservicerolemapping view) so the view stays untouched
+    // and no other service line's query is affected. Returns nothing for any
+    // user whose rows don't have NikshayTUID set (i.e. every non-Stop-TB user).
+    // NikshayTUID/NikshayFacilityID are TEXT columns holding a comma-joined
+    // list of IDs per row (e.g. "12,45,78"), not a single ID, so the TU/Facility
+    // master tables are joined with FIND_IN_SET rather than plain equality —
+    // an equality join here would silently match only the first ID in the list
+    // (MySQL casts "12,45" to 12 for numeric comparison) and drop the rest.
+    //
+    // DistrictID on this row is a Nikshay district ID, not an AMRIT one (see
+    // setWorkLocationObject in Admin-UI) - resolving its name against
+    // m_nikshay_district (the same ID space) is safe, unlike joining it
+    // against AMRIT's own m_district, which would silently match whatever
+    // AMRIT district happens to share that same numeric ID by coincidence.
+    @Query(value = "SELECT " +
+            "GROUP_CONCAT(DISTINCT usrm.NikshayTUID ORDER BY usrm.NikshayTUID), " +
+            "GROUP_CONCAT(DISTINCT nt.TUName ORDER BY nt.NikshayTUID), " +
+            "GROUP_CONCAT(DISTINCT usrm.NikshayFacilityID ORDER BY usrm.NikshayFacilityID), " +
+            "GROUP_CONCAT(DISTINCT nf.FacilityName ORDER BY nf.NikshayFacilityID), " +
+            "usrm.DistrictID, nd.DistrictName " +
+            "FROM m_userservicerolemapping usrm " +
+            "LEFT JOIN m_nikshay_tu nt ON FIND_IN_SET(nt.NikshayTUID, usrm.NikshayTUID) > 0 " +
+            "LEFT JOIN m_nikshay_facility nf ON FIND_IN_SET(nf.NikshayFacilityID, usrm.NikshayFacilityID) > 0 " +
+            "LEFT JOIN m_nikshay_district nd ON nd.NikshayDistrictID = usrm.DistrictID " +
+            "WHERE usrm.UserID = :userId AND usrm.ProviderServiceMapID = :providerServiceMapId " +
+            "AND usrm.Deleted = false AND usrm.NikshayTUID IS NOT NULL " +
+            "GROUP BY usrm.DistrictID, nd.DistrictName",
+            nativeQuery = true)
+    List<Object[]> getNikshayLocationScope(@Param("userId") Integer userId,
+                                            @Param("providerServiceMapId") Integer providerServiceMapId);
+
 }

--- a/src/main/java/com/iemr/flw/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/iemr/flw/service/impl/UserServiceImpl.java
@@ -23,7 +23,22 @@ public class UserServiceImpl implements UserService {
         logger.info("calling getUserRole for userId: " + userId);
         UserServiceRoleDTO userRole = userServiceRoleRepo.getUserRole(userId).get(0);
         userRole.setFacilityData(facilityDataService.buildFacilityData(userId, userRole.getRoleName()));
-        if (userRole.getWorkingDistrictId() == null && userRole.getBlockId() != null) {
+
+        // Stop TB / Nikshay — additive only. This naturally returns nothing for
+        // any user whose rows don't have NikshayTUID set, i.e. every non-Stop-TB
+        // user. Fetched first so the district-by-block patch below can tell
+        // Stop TB users apart and skip them.
+        java.util.List<Object[]> nikshayResults = userServiceRoleRepo.getNikshayLocationScope(userId, userRole.getProviderServiceMapId());
+        boolean isStopTBUser = nikshayResults != null && !nikshayResults.isEmpty()
+                && nikshayResults.get(0) != null && nikshayResults.get(0).length == 6
+                && nikshayResults.get(0)[0] != null;
+
+        // Stop TB's BlockId holds a Nikshay TU ID, not an AMRIT BlockID -
+        // joining it against m_districtblock/m_district (what
+        // getDistrictByBlockId does) would resolve to whatever AMRIT
+        // district happens to share that same numeric ID by coincidence,
+        // not real data. Skip this patch for Stop TB users.
+        if (!isStopTBUser && userRole.getWorkingDistrictId() == null && userRole.getBlockId() != null) {
             java.util.List<Object[]> districtResults = userServiceRoleRepo.getDistrictByBlockId(userRole.getBlockId());
             if (districtResults != null && !districtResults.isEmpty()) {
                 Object[] district = districtResults.get(0);
@@ -33,6 +48,26 @@ public class UserServiceImpl implements UserService {
                 }
             }
         }
+
+        if (isStopTBUser) {
+            Object[] nikshay = nikshayResults.get(0);
+            userRole.setTuId((String) nikshay[0]);
+            userRole.setTuName((String) nikshay[1]);
+            userRole.setHealthFacilityId((String) nikshay[2]);
+            userRole.setHealthFacilityName((String) nikshay[3]);
+            // Stop TB never sets WorkingLocationID, so workingDistrictId/Name
+            // (derived from it) are always null. DistrictID sits directly on
+            // the mapping row instead - Stop TB has no "work location"
+            // indirection layer the way other servicelines do, so read it
+            // straight from there rather than trying to derive it.
+            if (nikshay[4] != null) {
+                userRole.setWorkingDistrictId(((Number) nikshay[4]).intValue());
+            }
+            if (nikshay[5] != null) {
+                userRole.setWorkingDistrictName((String) nikshay[5]);
+            }
+        }
+
         return userRole;
     }
 }


### PR DESCRIPTION
release-3.8.2 predates the Nikshay TU/Facility/Village work done on release-3.8.3, so getUserDetail had no way to tell Stop TB users apart and was patching their district from the wrong source (BlockId holds a Nikshay TU ID for Stop TB, not an AMRIT BlockID).

Ports the getUserDetail-side fix from vb/release-3.8.3-nikshay-fix onto 3.8.2 as an additive change, keeping the existing facilityData/ FacilityDataService wiring intact for every other service line.

## 📋 Description

JIRA ID: 

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
