### PR TITLE
fix(nikshay): replace FIND_IN_SET master-table scan with indexed look…

### DIFF
--- a/src/main/java/com/iemr/flw/repo/iemr/UserServiceRoleRepo.java
+++ b/src/main/java/com/iemr/flw/repo/iemr/UserServiceRoleRepo.java
@@ -33,32 +33,33 @@ public interface UserServiceRoleRepo extends JpaRepository<UserServiceRole, Inte
     // (NOT the shared v_userservicerolemapping view) so the view stays untouched
     // and no other service line's query is affected. Returns nothing for any
     // user whose rows don't have NikshayTUID set (i.e. every non-Stop-TB user).
-    // NikshayTUID/NikshayFacilityID are TEXT columns holding a comma-joined
-    // list of IDs per row (e.g. "12,45,78"), not a single ID, so the TU/Facility
-    // master tables are joined with FIND_IN_SET rather than plain equality —
-    // an equality join here would silently match only the first ID in the list
-    // (MySQL casts "12,45" to 12 for numeric comparison) and drop the rest.
-    //
-    // DistrictID on this row is a Nikshay district ID, not an AMRIT one (see
-    // setWorkLocationObject in Admin-UI) - resolving its name against
-    // m_nikshay_district (the same ID space) is safe, unlike joining it
-    // against AMRIT's own m_district, which would silently match whatever
-    // AMRIT district happens to share that same numeric ID by coincidence.
-    @Query(value = "SELECT " +
-            "GROUP_CONCAT(DISTINCT usrm.NikshayTUID ORDER BY usrm.NikshayTUID), " +
-            "GROUP_CONCAT(DISTINCT nt.TUName ORDER BY nt.NikshayTUID), " +
-            "GROUP_CONCAT(DISTINCT usrm.NikshayFacilityID ORDER BY usrm.NikshayFacilityID), " +
-            "GROUP_CONCAT(DISTINCT nf.FacilityName ORDER BY nf.NikshayFacilityID), " +
-            "usrm.DistrictID, nd.DistrictName " +
+    // NikshayTUID/NikshayFacilityID are TEXT columns holding a comma-joined list
+    // of IDs (e.g. "12,45,78"), not a single ID. Name resolution against
+    // m_nikshay_tu/m_nikshay_facility is done in Java (see UserServiceImpl) via
+    // an indexed IN(...) lookup on their primary keys, instead of joining here
+    // with FIND_IN_SET — FIND_IN_SET can't use an index on either side, so it
+    // forces a full scan of the master table per call (measured: ~60s against
+    // m_nikshay_facility's 300k+ rows for a user with ~100 mapped facilities).
+    @Query(value = "SELECT usrm.NikshayTUID, usrm.NikshayFacilityID, usrm.DistrictID " +
             "FROM m_userservicerolemapping usrm " +
-            "LEFT JOIN m_nikshay_tu nt ON FIND_IN_SET(nt.NikshayTUID, usrm.NikshayTUID) > 0 " +
-            "LEFT JOIN m_nikshay_facility nf ON FIND_IN_SET(nf.NikshayFacilityID, usrm.NikshayFacilityID) > 0 " +
-            "LEFT JOIN m_nikshay_district nd ON nd.NikshayDistrictID = usrm.DistrictID " +
             "WHERE usrm.UserID = :userId AND usrm.ProviderServiceMapID = :providerServiceMapId " +
-            "AND usrm.Deleted = false AND usrm.NikshayTUID IS NOT NULL " +
-            "GROUP BY usrm.DistrictID, nd.DistrictName",
+            "AND usrm.Deleted = false AND usrm.NikshayTUID IS NOT NULL",
             nativeQuery = true)
-    List<Object[]> getNikshayLocationScope(@Param("userId") Integer userId,
-                                            @Param("providerServiceMapId") Integer providerServiceMapId);
+    List<Object[]> getNikshayMappingRows(@Param("userId") Integer userId,
+                                          @Param("providerServiceMapId") Integer providerServiceMapId);
+
+    @Query(value = "SELECT NikshayTUID, TUName FROM m_nikshay_tu WHERE NikshayTUID IN (:ids)", nativeQuery = true)
+    List<Object[]> findNikshayTuNames(@Param("ids") java.util.Collection<Integer> ids);
+
+    @Query(value = "SELECT NikshayFacilityID, FacilityName FROM m_nikshay_facility WHERE NikshayFacilityID IN (:ids)", nativeQuery = true)
+    List<Object[]> findNikshayFacilityNames(@Param("ids") java.util.Collection<Integer> ids);
+
+    // DistrictID on m_userservicerolemapping is a Nikshay district ID, not an
+    // AMRIT one (see setWorkLocationObject in Admin-UI) - resolving its name
+    // against m_nikshay_district (the same ID space) is safe, unlike joining it
+    // against AMRIT's own m_district, which would silently match whatever AMRIT
+    // district happens to share that same numeric ID by coincidence.
+    @Query(value = "SELECT DistrictName FROM m_nikshay_district WHERE NikshayDistrictID = :id", nativeQuery = true)
+    String findNikshayDistrictName(@Param("id") Integer id);
 
 }

--- a/src/main/java/com/iemr/flw/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/iemr/flw/service/impl/UserServiceImpl.java
@@ -8,6 +8,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
 @Service
 public class UserServiceImpl implements UserService {
 
@@ -23,10 +30,8 @@ public class UserServiceImpl implements UserService {
         // any user whose rows don't have NikshayTUID set, i.e. every non-Stop-TB
         // user. Fetched first so the district-by-block patch below can tell
         // Stop TB users apart and skip them.
-        java.util.List<Object[]> nikshayResults = userServiceRoleRepo.getNikshayLocationScope(userId, userRole.getProviderServiceMapId());
-        boolean isStopTBUser = nikshayResults != null && !nikshayResults.isEmpty()
-                && nikshayResults.get(0) != null && nikshayResults.get(0).length == 6
-                && nikshayResults.get(0)[0] != null;
+        List<Object[]> nikshayRows = userServiceRoleRepo.getNikshayMappingRows(userId, userRole.getProviderServiceMapId());
+        boolean isStopTBUser = nikshayRows != null && !nikshayRows.isEmpty();
 
         // Stop TB's BlockId holds a Nikshay TU ID, not an AMRIT BlockID -
         // joining it against m_districtblock/m_district (what
@@ -34,7 +39,7 @@ public class UserServiceImpl implements UserService {
         // district happens to share that same numeric ID by coincidence,
         // not real data. Skip this patch for Stop TB users.
         if (!isStopTBUser && userRole.getWorkingDistrictId() == null && userRole.getBlockId() != null) {
-            java.util.List<Object[]> districtResults = userServiceRoleRepo.getDistrictByBlockId(userRole.getBlockId());
+            List<Object[]> districtResults = userServiceRoleRepo.getDistrictByBlockId(userRole.getBlockId());
             if (districtResults != null && !districtResults.isEmpty()) {
                 Object[] district = districtResults.get(0);
                 if (district != null && district.length == 2) {
@@ -45,24 +50,67 @@ public class UserServiceImpl implements UserService {
         }
 
         if (isStopTBUser) {
-            Object[] nikshay = nikshayResults.get(0);
-            userRole.setTuId((String) nikshay[0]);
-            userRole.setTuName((String) nikshay[1]);
-            userRole.setHealthFacilityId((String) nikshay[2]);
-            userRole.setHealthFacilityName((String) nikshay[3]);
+            TreeSet<Integer> tuIds = new TreeSet<>();
+            TreeSet<Integer> facilityIds = new TreeSet<>();
+            Integer districtId = null;
+            for (Object[] row : nikshayRows) {
+                addCsvIds((String) row[0], tuIds);
+                addCsvIds((String) row[1], facilityIds);
+                if (districtId == null && row[2] != null) {
+                    districtId = ((Number) row[2]).intValue();
+                }
+            }
+
+            Map<Integer, String> tuNames = tuIds.isEmpty() ? Map.of()
+                    : toIdNameMap(userServiceRoleRepo.findNikshayTuNames(tuIds));
+            Map<Integer, String> facilityNames = facilityIds.isEmpty() ? Map.of()
+                    : toIdNameMap(userServiceRoleRepo.findNikshayFacilityNames(facilityIds));
+
+            userRole.setTuId(joinIds(tuIds));
+            userRole.setTuName(joinNames(tuIds, tuNames));
+            userRole.setHealthFacilityId(joinIds(facilityIds));
+            userRole.setHealthFacilityName(joinNames(facilityIds, facilityNames));
+
             // Stop TB never sets WorkingLocationID, so workingDistrictId/Name
             // (derived from it) are always null. DistrictID sits directly on
             // the mapping row instead - Stop TB has no "work location"
             // indirection layer the way other servicelines do, so read it
             // straight from there rather than trying to derive it.
-            if (nikshay[4] != null) {
-                userRole.setWorkingDistrictId(((Number) nikshay[4]).intValue());
-            }
-            if (nikshay[5] != null) {
-                userRole.setWorkingDistrictName((String) nikshay[5]);
+            if (districtId != null) {
+                userRole.setWorkingDistrictId(districtId);
+                userRole.setWorkingDistrictName(userServiceRoleRepo.findNikshayDistrictName(districtId));
             }
         }
 
         return userRole;
+    }
+
+    private void addCsvIds(String csv, Collection<Integer> target) {
+        if (csv == null || csv.isBlank()) {
+            return;
+        }
+        for (String id : csv.split(",")) {
+            try {
+                target.add(Integer.valueOf(id.trim()));
+            } catch (NumberFormatException ignored) {
+                // skip malformed entries rather than fail the whole login
+            }
+        }
+    }
+
+    private Map<Integer, String> toIdNameMap(List<Object[]> rows) {
+        Map<Integer, String> map = new HashMap<>();
+        for (Object[] row : rows) {
+            map.put(((Number) row[0]).intValue(), (String) row[1]);
+        }
+        return map;
+    }
+
+    private String joinIds(Collection<Integer> ids) {
+        return ids.stream().map(String::valueOf).collect(Collectors.joining(","));
+    }
+
+    private String joinNames(Collection<Integer> ids, Map<Integer, String> names) {
+        return ids.stream().map(id -> names.getOrDefault(id, "")).collect(Collectors.joining(","));
     }
 }


### PR DESCRIPTION
…ups in getUserDetail

getNikshayLocationScope joined m_nikshay_tu/m_nikshay_facility with FIND_IN_SET(masterId, usrm.csvColumn) > 0, which can't use an index on either side and forces a full table scan per login. Measured ~60s for a Stop TB user with ~100 mapped facilities against m_nikshay_facility's 300k+ rows.

Replace with a plain fetch of the raw CSV columns off m_userservicerolemapping (indexed by UserID+ProviderServiceMapID), then resolve TU/Facility/District names via IN(...) lookups on their primary keys, reassembling the same comma-joined tuId/tuName/ healthFacilityId/healthFacilityName strings in Java. Measured ~3s for the same user after the change.

## 📋 Description

JIRA ID: 

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
