### PR TITLE
fix(dynamicform): stamp VanSerialNo on form/section/question responses

### DIFF
--- a/src/main/java/com/iemr/flw/repo/iemr/FormResponseRepo.java
+++ b/src/main/java/com/iemr/flw/repo/iemr/FormResponseRepo.java
@@ -22,6 +22,7 @@
 package com.iemr.flw.repo.iemr;
 
 import com.iemr.flw.domain.iemr.FormResponse;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -69,4 +70,10 @@ public interface FormResponseRepo extends JpaRepository<FormResponse, Long> {
             @Param("formIds") List<Long> formIds,
             @Param("windowStart") Timestamp windowStart,
             @Param("windowEnd") Timestamp windowEnd);
+
+    // See SectionResponseRepo.updateVanSerialNo for why this is a targeted UPDATE, not a
+    // second full-entity save.
+    @Modifying
+    @Query("UPDATE FormResponse f SET f.vanSerialNo = :vanSerialNo WHERE f.responseId = :id")
+    void updateVanSerialNo(@Param("id") Long id, @Param("vanSerialNo") Long vanSerialNo);
 }

--- a/src/main/java/com/iemr/flw/repo/iemr/QuestionResponseRepo.java
+++ b/src/main/java/com/iemr/flw/repo/iemr/QuestionResponseRepo.java
@@ -23,6 +23,9 @@ package com.iemr.flw.repo.iemr;
 
 import com.iemr.flw.domain.iemr.QuestionResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Collection;
@@ -43,4 +46,10 @@ public interface QuestionResponseRepo extends JpaRepository<QuestionResponse, Lo
     void deleteByQuestionIdAndSectionResponseId(Long questionId, Long sectionResponseId);
 
     void deleteBySectionResponseIdIn(Collection<Long> sectionResponseIds);
+
+    // See SectionResponseRepo.updateVanSerialNo for why this is a targeted UPDATE, not a
+    // second full-entity save.
+    @Modifying
+    @Query("UPDATE QuestionResponse q SET q.vanSerialNo = :vanSerialNo WHERE q.questionResponseId = :id")
+    void updateVanSerialNo(@Param("id") Long id, @Param("vanSerialNo") Long vanSerialNo);
 }

--- a/src/main/java/com/iemr/flw/repo/iemr/SectionResponseRepo.java
+++ b/src/main/java/com/iemr/flw/repo/iemr/SectionResponseRepo.java
@@ -24,6 +24,7 @@ package com.iemr.flw.repo.iemr;
 import com.iemr.flw.domain.iemr.SectionResponse;
 import com.iemr.flw.masterEnum.SectionPhase;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -54,4 +55,13 @@ public interface SectionResponseRepo extends JpaRepository<SectionResponse, Long
            "AND sr.responseId IN :responseIds GROUP BY sr.responseId")
     List<Object[]> countByResponseIdInAndSectionPhase(@Param("responseIds") Collection<Long> responseIds,
                                                        @Param("sectionPhase") SectionPhase sectionPhase);
+
+    // vanSerialNo is never set at creation time (no van-context available yet on a plain
+    // .save()) - called right after save() once the auto-generated sectionResponseId is
+    // known, matching the "VanSerialNo == own PK" convention used across this codebase.
+    // A targeted UPDATE, not a second full-entity save - see BeneficiaryServiceImpl/
+    // CommonBenStatusFlowServiceImpl for why a full re-save is the wrong fix here.
+    @Modifying
+    @Query("UPDATE SectionResponse s SET s.vanSerialNo = :vanSerialNo WHERE s.sectionResponseId = :id")
+    void updateVanSerialNo(@Param("id") Long id, @Param("vanSerialNo") Long vanSerialNo);
 }

--- a/src/main/java/com/iemr/flw/service/impl/DynamicFormResponseServiceImpl.java
+++ b/src/main/java/com/iemr/flw/service/impl/DynamicFormResponseServiceImpl.java
@@ -202,7 +202,9 @@ public class DynamicFormResponseServiceImpl implements DynamicFormResponseServic
                 .vanID(vanID)
                 .parkingPlaceID(parkingPlaceID)
                 .build();
-        return formResponseRepo.save(formResponse);
+        formResponse = formResponseRepo.save(formResponse);
+        formResponseRepo.updateVanSerialNo(formResponse.getResponseId(), formResponse.getResponseId());
+        return formResponse;
     }
 
     /**
@@ -286,7 +288,10 @@ public class DynamicFormResponseServiceImpl implements DynamicFormResponseServic
                     vanID,
                     parkingPlaceID);
 
-            questionResponseRepo.saveAll(questionResponses);
+            questionResponses = questionResponseRepo.saveAll(questionResponses);
+            for (QuestionResponse qr : questionResponses) {
+                questionResponseRepo.updateVanSerialNo(qr.getQuestionResponseId(), qr.getQuestionResponseId());
+            }
 
             sectionDTOs.add(buildSectionResponseDTO(sectionResponse, section, questionResponses));
         }
@@ -310,7 +315,9 @@ public class DynamicFormResponseServiceImpl implements DynamicFormResponseServic
                 sr.setSavedAt(new Timestamp(System.currentTimeMillis()));
                 sr.setUpdatedBy(actor);
                 if (sr.getVanID() == null) { sr.setVanID(vanID); sr.setParkingPlaceID(parkingPlaceID); }
-                return Optional.of(sectionResponseRepo.save(sr));
+                SectionResponse updated = sectionResponseRepo.save(sr);
+                sectionResponseRepo.updateVanSerialNo(updated.getSectionResponseId(), updated.getSectionResponseId());
+                return Optional.of(updated);
             }
         }
         // POST_SUBMIT sections always create a new instance — this is what makes repeatable
@@ -325,7 +332,9 @@ public class DynamicFormResponseServiceImpl implements DynamicFormResponseServic
                 .vanID(vanID)
                 .parkingPlaceID(parkingPlaceID)
                 .build();
-        return Optional.of(sectionResponseRepo.save(sr));
+        sr = sectionResponseRepo.save(sr);
+        sectionResponseRepo.updateVanSerialNo(sr.getSectionResponseId(), sr.getSectionResponseId());
+        return Optional.of(sr);
     }
 
     private List<QuestionResponse> processAnswers(

--- a/src/main/java/com/iemr/flw/service/impl/FormResponseItemSaver.java
+++ b/src/main/java/com/iemr/flw/service/impl/FormResponseItemSaver.java
@@ -195,7 +195,9 @@ public class FormResponseItemSaver {
                 .vanID(vanID)
                 .parkingPlaceID(parkingPlaceID)
                 .build();
-        return formResponseRepo.save(formResponse);
+        formResponse = formResponseRepo.save(formResponse);
+        formResponseRepo.updateVanSerialNo(formResponse.getResponseId(), formResponse.getResponseId());
+        return formResponse;
     }
 
     private FormResponseDTO processSections(FormResponse formResponse, FormResponseRequest req, FormVersion version, String actor,
@@ -265,7 +267,10 @@ public class FormResponseItemSaver {
                     vanID,
                     parkingPlaceID);
 
-            questionResponseRepo.saveAll(questionResponses);
+            questionResponses = questionResponseRepo.saveAll(questionResponses);
+            for (QuestionResponse qr : questionResponses) {
+                questionResponseRepo.updateVanSerialNo(qr.getQuestionResponseId(), qr.getQuestionResponseId());
+            }
             sectionDTOs.add(buildSectionResponseDTO(sectionResponse, section, questionResponses));
         }
 
@@ -288,7 +293,9 @@ public class FormResponseItemSaver {
                 sr.setSavedAt(new Timestamp(System.currentTimeMillis()));
                 sr.setUpdatedBy(actor);
                 if (sr.getVanID() == null) { sr.setVanID(vanID); sr.setParkingPlaceID(parkingPlaceID); }
-                return Optional.of(sectionResponseRepo.save(sr));
+                SectionResponse updated = sectionResponseRepo.save(sr);
+                sectionResponseRepo.updateVanSerialNo(updated.getSectionResponseId(), updated.getSectionResponseId());
+                return Optional.of(updated);
             }
         }
         // POST_SUBMIT sections always create a new instance — this is what makes repeatable
@@ -303,7 +310,9 @@ public class FormResponseItemSaver {
                 .vanID(vanID)
                 .parkingPlaceID(parkingPlaceID)
                 .build();
-        return Optional.of(sectionResponseRepo.save(sr));
+        sr = sectionResponseRepo.save(sr);
+        sectionResponseRepo.updateVanSerialNo(sr.getSectionResponseId(), sr.getSectionResponseId());
+        return Optional.of(sr);
     }
 
     private List<QuestionResponse> processAnswers(


### PR DESCRIPTION
t_form_response, t_section_response, t_question_response all have a mapped vanSerialNo column, and VanID/parkingPlaceID were already being correctly stamped via campConfigService.getVanID() - but nothing in either save path (DynamicFormResponseServiceImpl or the parallel FormResponseItemSaver. saveForBulk bulk-save path) ever set vanSerialNo. Every response record created through either path would have vanSerialNo=NULL forever - the same class of bug fixed multiple times elsewhere in this codebase today, this time caught via code review before it caused a live sync failure (both tables currently have 0 real rows - no counsellor has completed a session against this fix yet).

Fixed with a targeted UPDATE right after each save(), once the auto-generated PK is known - not a second full-entity save, which is the anti-pattern that caused the earlier deleted=NULL regression on i_ben_flow_outreach today (see BeneficiaryServiceImpl/ CommonBenStatusFlowServiceImpl history).

No DB/schema change needed - all 3 columns already existed from V87.

Not yet registered for sync (m_synctabledetail / central VALID_TABLES) - that's a separate step, same as the diagnostic-device tables earlier today.

## 📋 Description

JIRA ID: 

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
