### PR TITLE
fix(stoptb): read vanID from stoptb.van.id property instead of Redis

### DIFF
--- a/src/main/environment/common_ci.properties
+++ b/src/main/environment/common_ci.properties
@@ -29,6 +29,8 @@ spring.redis.host=@env.REDIS_HOST@
 
 # Stop TB: when true, saves fail with an error if camp (vanID) is not configured
 stoptb.enforce.vanid=@env.STOPTB_ENFORCE_VANID@
+# Stop TB: this deployment's van/camp ID, replacing the old Redis camp:vanID lookup
+stoptb.van.id=@env.STOPTB_VAN_ID@
 
 cors.allowed-origins=@env.CORS_ALLOWED_ORIGINS@
 

--- a/src/main/environment/common_docker.properties
+++ b/src/main/environment/common_docker.properties
@@ -29,6 +29,8 @@ spring.redis.host=${REDIS_HOST}
 
 # Stop TB: when true, saves fail with an error if camp (vanID) is not configured
 stoptb.enforce.vanid=${STOPTB_ENFORCE_VANID}
+# Stop TB: this deployment's van/camp ID, replacing the old Redis camp:vanID lookup
+stoptb.van.id=${STOPTB_VAN_ID}
 
 #### SMS Configuration
 send-sms=${SEND_SMS}

--- a/src/main/environment/common_example.properties
+++ b/src/main/environment/common_example.properties
@@ -31,6 +31,8 @@ spring.redis.host=localhost
 # Stop TB: when true, saves fail with an error if camp (vanID) is not configured
 # instead of silently storing vanID=NULL (which then never gets synced to central)
 stoptb.enforce.vanid=false
+# Stop TB: this deployment's van/camp ID, replacing the old Redis camp:vanID lookup
+stoptb.van.id=0
 
 cors.allowed-origins=http://localhost:*
 

--- a/src/main/java/com/iemr/flw/service/CampConfigService.java
+++ b/src/main/java/com/iemr/flw/service/CampConfigService.java
@@ -1,61 +1,54 @@
 package com.iemr.flw.service;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.connection.RedisConnection;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.stereotype.Service;
 
+/**
+ * Camp/van identity for this deployment.
+ *
+ * Previously read from Redis ("camp:vanID"), written at MMU login and deleted (globally,
+ * unscoped) on ANY user's logout — a Redis outage or an unrelated user's logout would silently
+ * break every Stop TB save on this camp. Each camp/van already runs its own dedicated backend
+ * instance against its own local DB, so which van this is never actually changes at runtime —
+ * it's a property of the deployment, not a login-time session value. Reading it from properties
+ * instead removes the Redis dependency entirely and fixes the global-key bug as a side effect
+ * (see stoptb-camp-vanid-global-key-bug investigation).
+ *
+ * No inline default — every properties file must set stoptb.van.id explicitly, so a forgotten
+ * config fails loudly at startup instead of silently running unconfigured.
+ *
+ * Scope: vanID (and the VanSerialNo stamping that depends on it) only. parkingPlaceID is out of
+ * scope for this change.
+ */
 @Service
 public class CampConfigService {
 
-    private static final Logger logger = LoggerFactory.getLogger(CampConfigService.class);
-    private static final String VAN_ID_KEY = "camp:vanID";
-    private static final String PARKING_PLACE_ID_KEY = "camp:parkingPlaceID";
+    @Value("${stoptb.van.id}")
+    private int vanID;
 
-    @Autowired
-    private LettuceConnectionFactory connectionFactory;
-
-    // When true, saves fail loudly if camp is not configured instead of silently storing vanID=NULL.
-    // No inline default — every properties file must set this explicitly, so a forgotten
-    // config fails loudly at startup instead of running fail-open.
+    // When true, saves fail loudly if camp is not configured (vanID=0) instead of silently
+    // storing vanID=NULL. No inline default — every properties file must set this explicitly.
     @Value("${stoptb.enforce.vanid}")
     private boolean enforceVanID;
 
     public Integer getVanID() {
-        String val = read(VAN_ID_KEY);
-        if (val == null || val.isBlank()) {
+        if (vanID <= 0) {
             if (enforceVanID) {
                 throw new IllegalStateException(
-                    "Camp not configured: vanID missing. Please select van/service point in MMU before saving Stop TB data.");
+                    "Camp not configured: stoptb.van.id is 0. Set stoptb.van.id in this deployment's properties file.");
             }
             return null;
         }
-        return Integer.parseInt(val);
-    }
-
-    public Integer getParkingPlaceID() {
-        String val = read(PARKING_PLACE_ID_KEY);
-        if (val == null || val.isBlank()) return 0;
-        return Integer.parseInt(val);
+        return vanID;
     }
 
     public boolean isCampConfigured() {
-        String val = read(VAN_ID_KEY);
-        return val != null && !val.isBlank();
+        return vanID > 0;
     }
 
-    private String read(String key) {
-        try {
-            RedisConnection conn = connectionFactory.getConnection();
-            byte[] data = conn.get(key.getBytes());
-            conn.close();
-            return data != null ? new String(data) : null;
-        } catch (Exception e) {
-            logger.error("Redis read error for key {}: {}", key, e.getMessage());
-            return null;
-        }
+    // Not sourced from Redis anymore (out of scope for this change) — kept only because
+    // callers across StopTBServiceImpl/DiagnosticOrderServiceImpl/etc. still call it.
+    public Integer getParkingPlaceID() {
+        return 0;
     }
 }


### PR DESCRIPTION
Redis (camp:vanID) was written once at MMU login and deleted globally, unscoped, on ANY user's logout — a Redis outage or an unrelated user's logout would silently break every Stop TB save on this camp. Each camp/van already runs its own dedicated backend instance against its own local DB, so which van this is never actually changes at runtime; it's a property of the deployment, not a login-time session value.

CampConfigService.getVanID() now reads stoptb.van.id (no inline default — every properties file must set it explicitly, same convention as stoptb.enforce.vanid). enforceVanID throw/return-null logic is unchanged, just fed from the new source.

Scope: vanID (and the VanSerialNo stamping that depends on it) only. getParkingPlaceID() is kept (12 call sites depend on it) but always returns 0 now — parkingPlaceID is out of scope for this change.

## 📋 Description

JIRA ID: 

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
