### PR TITLE
fix(stoptb): self-heal VanSerialNo instead of trusting a stale isNew …

### DIFF
--- a/src/main/java/com/iemr/flw/service/impl/DiagnosticDocumentServiceImpl.java
+++ b/src/main/java/com/iemr/flw/service/impl/DiagnosticDocumentServiceImpl.java
@@ -78,7 +78,6 @@ public class DiagnosticDocumentServiceImpl implements DiagnosticDocumentService 
         Path filePath = dir.resolve(storedFileName);
         Files.write(filePath, encryptedPayload.getBytes(StandardCharsets.UTF_8));
 
-        boolean isNewDocument = existing.isEmpty();
         DiagnosticDocument document = existing.orElseGet(DiagnosticDocument::new);
         if (document.getVanID() == null) {
             // Inherit from the parent order rather than re-reading Redis — the document belongs
@@ -102,7 +101,7 @@ public class DiagnosticDocumentServiceImpl implements DiagnosticDocumentService 
         document.setCreatedBy("SYSTEM");
         try {
             diagnosticDocumentRepo.save(document);
-            if (isNewDocument) diagnosticDocumentRepo.updateVanSerialNo(document.getId());
+            if (document.getVanSerialNo() == null) diagnosticDocumentRepo.updateVanSerialNo(document.getId());
         } catch (DataIntegrityViolationException dive) {
             logger.warn("Lost document upsert race for diagnosticOrderId={}, documentType={}", diagnosticOrderId, documentType);
             return;

--- a/src/main/java/com/iemr/flw/service/impl/DiagnosticOrderServiceImpl.java
+++ b/src/main/java/com/iemr/flw/service/impl/DiagnosticOrderServiceImpl.java
@@ -76,7 +76,6 @@ public class DiagnosticOrderServiceImpl implements DiagnosticOrderService {
             return existing.get();
         }
 
-        boolean isNew = existing.isEmpty();
         DiagnosticOrder order = existing.orElseGet(DiagnosticOrder::new);
         if (order.getVanID() == null) {
             order.setVanID(campConfigService.getVanID());
@@ -133,7 +132,11 @@ public class DiagnosticOrderServiceImpl implements DiagnosticOrderService {
             order.setErrorMessage(e.getMessage());
         }
         order = diagnosticOrderRepo.save(order);
-        if (isNew) diagnosticOrderRepo.updateVanSerialNo(order.getId());
+        // Check the field itself, not a point-in-time "isNew" flag — a flag computed before save()
+        // goes stale forever once the row exists (e.g. this row was the "winner" of a lost create
+        // race below, or a prior attempt crashed between save() and this line). Re-checking the
+        // real value self-heals any row still stuck at NULL, on whichever call next touches it.
+        if (order.getVanSerialNo() == null) diagnosticOrderRepo.updateVanSerialNo(order.getId());
 
         return order;
     }
@@ -151,7 +154,6 @@ public class DiagnosticOrderServiceImpl implements DiagnosticOrderService {
             latest = Optional.empty();
         }
 
-        boolean isNew = latest.isEmpty();
         DiagnosticOrder order = latest.orElseGet(DiagnosticOrder::new);
         if (order.getVanID() == null) {
             order.setVanID(campConfigService.getVanID());
@@ -176,7 +178,7 @@ public class DiagnosticOrderServiceImpl implements DiagnosticOrderService {
 
         try {
             order = diagnosticOrderRepo.save(order);
-            if (isNew) diagnosticOrderRepo.updateVanSerialNo(order.getId());
+            if (order.getVanSerialNo() == null) diagnosticOrderRepo.updateVanSerialNo(order.getId());
             return order;
         } catch (DataIntegrityViolationException dive) {
             Optional<DiagnosticOrder> winner = diagnosticOrderRepo
@@ -193,7 +195,6 @@ public class DiagnosticOrderServiceImpl implements DiagnosticOrderService {
     @Override
     public DiagnosticOrderResultDto processResult(DiagnosticOrder order, DiagnosticPollResult pollResult) throws Exception {
         Optional<DiagnosticResult> existingResult = diagnosticResultRepo.findByDiagnosticOrderIdAndDeletedFalse(order.getId());
-        boolean isNewResult = existingResult.isEmpty();
         DiagnosticResult result = existingResult.orElseGet(DiagnosticResult::new);
         result.setDiagnosticOrderId(order.getId());
         result.setBeneficiaryId(order.getBeneficiaryId());
@@ -217,7 +218,7 @@ public class DiagnosticOrderServiceImpl implements DiagnosticOrderService {
         }
         try {
             diagnosticResultRepo.save(result);
-            if (isNewResult) diagnosticResultRepo.updateVanSerialNo(result.getId());
+            if (result.getVanSerialNo() == null) diagnosticResultRepo.updateVanSerialNo(result.getId());
         } catch (DataIntegrityViolationException dive) {
             logger.warn("Lost result upsert race for diagnosticOrderId={}", order.getId());
             result = diagnosticResultRepo.findByDiagnosticOrderIdAndDeletedFalse(order.getId()).orElse(result);


### PR DESCRIPTION
…flag

isNew was captured once, before save(), as existing.isEmpty(). If a row was created but the process was interrupted before the follow-up updateVanSerialNo() call (crash, lost create race, network blip), the row stays permanently NULL - every future touch finds the row already exists, so isNew evaluates false forever and the fix is never retried.

Replace the flag with a direct check of the field's real current value (order/result/document.getVanSerialNo() == null) in all 4 write paths across the 3 affected tables:
- tb_diagnostic_order: createAndPushOrder(), saveRefusedOrder()
- tb_diagnostic_result: processResult()
- tb_diagnostic_document: ingestAsset()

Behavior for the clean single-pass path is unchanged (still stamped once, no redundant UPDATE on already-correct rows). The only added behavior is that any row previously stuck at VanSerialNo=NULL now self-heals on its next touch instead of staying broken forever.

## 📋 Description

JIRA ID: 

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
